### PR TITLE
Docs: Update Remix imports

### DIFF
--- a/docs/docs/tutorial-basics/create-loader.md
+++ b/docs/docs/tutorial-basics/create-loader.md
@@ -8,7 +8,7 @@ Create a new resource route that imports the `imageLoader` function and exports 
 To do this, create a new file in `app/routes` such as `app/routes/api/image.js`.
 By default, the image component uses the route `"/api/image"`, but any route can be used.
 ```typescript jsx
-import type { LoaderFunction } from "remix";
+import type { LoaderFunction } from "@remix-run/server-runtime";
 import { imageLoader, DiskCache } from "remix-image/server";
 
 const config = {


### PR DESCRIPTION
Beginning with Remix version [1.4.0](https://github.com/remix-run/remix/releases/tag/v1.4.0) imports should be changed to point to the actual packages instead of "remix". I updated the "Create Loader" page of the basic tutorial to reflect this.