### PR TITLE
#31 wrong sizes order

### DIFF
--- a/src/hooks/responsiveImage.ts
+++ b/src/hooks/responsiveImage.ts
@@ -38,7 +38,10 @@ export const useResponsiveImage = (
   }
 
   const sizes = [...responsive]
-    .sort((resp1, resp2) => (resp1.maxWidth || Infinity) - (resp2.maxWidth || Infinity)
+    .sort(
+      (resp1, resp2) =>
+        (resp1.maxWidth || Infinity) - (resp2.maxWidth || Infinity)
+    )
     .map((resp) =>
       resp.maxWidth
         ? `(max-width: ${resp.maxWidth}px) ${resp.size.width}px`

--- a/src/hooks/responsiveImage.ts
+++ b/src/hooks/responsiveImage.ts
@@ -38,7 +38,7 @@ export const useResponsiveImage = (
   }
 
   const sizes = [...responsive]
-    .sort((resp1, resp2) => resp1.size.width - resp2.size.width)
+    .sort((resp1, resp2) => (resp1.maxWidth || Infinity) - (resp2.maxWidth || Infinity)
     .map((resp) =>
       resp.maxWidth
         ? `(max-width: ${resp.maxWidth}px) ${resp.size.width}px`


### PR DESCRIPTION
We need to sort HTML `sizes` property, eg.`sizes="(max-width: 769px) 800px, (max-width: 1024px) 1200px, 400px"`, by `max-width` value ascending, not by `size.width`. No `max-width` value should be on the end.

discussion: https://github.com/Josh-McFarlin/remix-image/issues/31