### PR TITLE
#28 make responsive property required

### DIFF
--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -6,7 +6,7 @@ import classes from "./Image.module.scss";
 
 export interface ImageProps extends React.ComponentProps<"img"> {
   loaderUrl?: string;
-  responsive?: ResponsiveSize[];
+  responsive: [ResponsiveSize, ...ResponsiveSize[]];
   options?: SizelessOptions;
 }
 
@@ -15,7 +15,7 @@ export const Image = React.forwardRef<HTMLImageElement, ImageProps>(
     {
       className,
       loaderUrl = "/api/image",
-      responsive = [],
+      responsive,
       options = {},
       ...imgProps
     },

--- a/src/hooks/responsiveImage.ts
+++ b/src/hooks/responsiveImage.ts
@@ -14,7 +14,7 @@ export type ResponsiveHookResult = {
 export const useResponsiveImage = (
   image: ImageSource,
   loaderUrl: string,
-  responsive: ResponsiveSize[],
+  responsive: [ResponsiveSize, ...ResponsiveSize[]],
   options: SizelessOptions = {}
 ): ResponsiveHookResult => {
   let largestSrc = image.src || "";


### PR DESCRIPTION
In my opinion we should not accept `Image` without `responsive` property or with empty `responsive` like:

```
<Image
  alt=""
  options={{
    contentType: MimeType.WEBP,
  }}
  src="https://images.unsplash.com/photo-1652303308996-0a0c780587f8"
  responsive={[]}
/>
```

Sometimes developers could forget about `responsive` property and that leads to performance issues (eg. in example above the image will not be transformed to .webp format).

discussion: https://github.com/Josh-McFarlin/remix-image/issues/28