### PR TITLE
chore: position property should be more flexible

### DIFF
--- a/docs/docs/component.md
+++ b/docs/docs/component.md
@@ -49,7 +49,7 @@ export interface TransformOptions {
   /** How the image should be resized to fit both provided dimensions. (optional, default 'contain') */
   fit?: ImageFit;
   /** Position to use when fit is cover or contain. (optional, default 'center') */
-  position?: ImagePosition;
+  position?: string;
   /** Background color of resulting image. (optional, default [0x00, 0x00, 0x00, 0x00]) */
   background?: Color;
   /** Quality, integer 1-100. (optional, default 80) */

--- a/docs/docs/hook.md
+++ b/docs/docs/hook.md
@@ -48,7 +48,7 @@ export interface TransformOptions {
   /** How the image should be resized to fit both provided dimensions. (optional, default 'contain') */
   fit?: ImageFit;
   /** Position to use when fit is cover or contain. (optional, default 'center') */
-  position?: ImagePosition;
+  position?: string;
   /** Background color of resulting image. (optional, default [0x00, 0x00, 0x00, 0x00]) */
   background?: Color;
   /** Quality, integer 1-100. (optional, default 80) */

--- a/docs/docs/tutorial-basics/use-component.md
+++ b/docs/docs/tutorial-basics/use-component.md
@@ -47,7 +47,7 @@ export interface TransformOptions {
   /** How the image should be resized to fit both provided dimensions. (optional, default 'contain') */
   fit?: ImageFit;
   /** Position to use when fit is cover or contain. (optional, default 'center') */
-  position?: ImagePosition;
+  position?: string;
   /** Background color of resulting image. (optional, default [0x00, 0x00, 0x00, 0x00]) */
   background?: Color;
   /** Quality, integer 1-100. (optional, default 80) */

--- a/src/server/loaders/imageLoader.ts
+++ b/src/server/loaders/imageLoader.ts
@@ -2,7 +2,6 @@ import { redirect } from "@remix-run/server-runtime";
 import mimeFromBuffer from "mime-tree";
 import {
   ImageFit,
-  ImagePosition,
   MimeType,
   TransformOptions,
   UnsupportedImageError,
@@ -56,7 +55,7 @@ export const imageLoader: AssetLoader = async (
     const decodedQuery = decodeTransformQuery(reqUrl.search);
     const transformOptions: TransformOptions = {
       fit: ImageFit.CONTAIN,
-      position: ImagePosition.CENTER,
+      position: "center",
       background: [0x00, 0x00, 0x00, 0x00],
       quality: 80,
       compressionLevel: 9,

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -19,12 +19,6 @@ export enum ImageFit {
   OUTSIDE = "outside",
 }
 
-export enum ImagePosition {
-  LEFT = "left",
-  CENTER = "center",
-  RIGHT = "right",
-}
-
 export enum FlipDirection {
   HORIZONTAL = "horizontal",
   VERTICAL = "vertical",
@@ -52,7 +46,7 @@ export interface TransformOptions {
   /** How the image should be resized to fit both provided dimensions. (optional, default 'contain') */
   fit?: ImageFit;
   /** Position to use when fit is cover or contain. (optional, default 'center') */
-  position?: ImagePosition;
+  position?: string;
   /** Background color of resulting image. (optional, default [0x00, 0x00, 0x00, 0x00]) */
   background?: Color;
   /** Quality, integer 1-100. (optional, default 80) */


### PR DESCRIPTION
I believe image `position` should not be limited to these three:

```
export enum ImagePosition {
  LEFT = "left",
  CENTER = "center",
  RIGHT = "right",
}
```

In [Sharp documentation](https://sharp.pixelplumbing.com/api-resize#resize) we read that it could more:

>When using a fit of cover or contain, the default position is centre. Other options are:
>sharp.position: top, right top, right, right bottom, bottom, left bottom, left, left top.

Potentially however it could be even more flexible, it could work with values same as CSS [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position), eg. `object-position: 250px 125px;`

I mentioned about it in https://github.com/Josh-McFarlin/remix-image/issues/32