### PR TITLE
fix(package): add rollup interop for next-boost/hybrid-disk-cache

### DIFF
--- a/packages/remix-image/rollup.config.js
+++ b/packages/remix-image/rollup.config.js
@@ -6,6 +6,7 @@ import typescript from "rollup-plugin-typescript2";
 import terser from "@rollup/plugin-terser";
 import replace from "@rollup/plugin-replace";
 import { version } from "./package.json";
+import { defineConfig } from "rollup";
 
 const external = ["fs", "path", "react", "react-dom"];
 
@@ -16,7 +17,7 @@ const tsSettings = {
   },
 };
 
-export default [
+export default defineConfig([
   {
     input: "src/index.tsx",
     output: [
@@ -57,6 +58,7 @@ export default [
         format: "cjs",
         sourcemap: true,
         exports: "named",
+        interop: "auto",
       },
     ],
     external,
@@ -76,10 +78,6 @@ export default [
         values: {
           __remix_image_version: version,
         },
-      }),
-      terser({
-        keep_fnames: true,
-        sourceMap: true,
       }),
     ],
   },
@@ -125,4 +123,4 @@ export default [
       }),
     ],
   },
-];
+]);


### PR DESCRIPTION
Add `interop: "auto"` to rollup config and remove terser transformation for remix-image/server

Terser is not useful for nodejs' only package and make debug harder

    BaseCache is not a constructor

is better than

    g is not a constructor

Closes #62